### PR TITLE
Fix form validation, submission UX, reset, and input validation bugs

### DIFF
--- a/projects/ngx-interactive-paycard-lib/src/lib/interactive-paycard.component.html
+++ b/projects/ngx-interactive-paycard-lib/src/lib/interactive-paycard.component.html
@@ -7,50 +7,72 @@
       [cardLabels]="resolvedCardLabels()"></lib-card>
   </div>
   <div class="card-form__inner">
-    <div class="card-input">
+    @if (submitSuccess()) {
+      <div class="card-form__success" role="alert">
+        <span class="card-form__success-icon">&#10003;</span>
+        Payment submitted successfully!
+      </div>
+    }
+    <div class="card-input" [class.-error]="submitted() && !isCardNumberValid()">
       <label for="cardNumber" class="card-input__label">{{resolvedFormLabels().cardNumber}}</label>
       <input class="card-input__input" type="tel" [id]="cardNumberId" [attr.maxlength]="cardNumberMaxLength()"
         [value]="displayedCardNumber()" (input)="onCardNumberChange($event)" (focus)="onCardNumberFocus()"
         (blur)="onCardNumberBlur()" autocomplete="off" />
+      @if (showAmexWarning()) {
+        <span class="card-input__error-msg">American Express cards are not supported.</span>
+      } @else if (submitted() && !isCardNumberValid()) {
+        <span class="card-input__error-msg">Please enter a valid card number.</span>
+      }
     </div>
-    <div class="card-input">
+    <div class="card-input" [class.-error]="submitted() && !isCardNameValid()">
       <label for="cardName" class="card-input__label">{{resolvedFormLabels().cardHolderName}}</label>
       <input class="card-input__input" type="text" [id]="cardNameId"
         [ngModel]="cardModel().cardName" (ngModelChange)="onCardNameChange($event)"
-        (keyup)='onCardNameKeyPress($event)' autocomplete="off" (focus)="onCardNameFocus()" (blur)="onBlur()" />
+        autocomplete="off" (focus)="onCardNameFocus()" (blur)="onBlur()" />
+      @if (submitted() && !isCardNameValid()) {
+        <span class="card-input__error-msg">Please enter the card holder name.</span>
+      }
     </div>
     <div class="card-form__row">
       <div class="card-form__col">
         <div class="card-form__group">
           <label for="cardMonth" class="card-input__label">{{resolvedFormLabels().expirationDate}}</label>
-          <select class="card-input__input -select" id="monthSelect"
-            [ngModel]="cardModel().expirationMonth" (ngModelChange)="onExpirationMonthChange($event)"
-            (focus)="onDateFocus()" (blur)="onBlur()">
-            <option value disabled selected>{{resolvedFormLabels().expirationMonth}}</option>
-            @for (element of [].constructor(12); track $index; let i = $index) {
-              <option [value]="(i+1) < 10 ? '0' + (i+1) : (i+1)" [disabled]="(i+1) < minCardMonth()">
-                {{generateMonthValue((i+1))}}
-              </option>
-            }
-          </select>
-          <select class="card-input__input -select" [id]="yearSelectId"
-            [ngModel]="cardModel().expirationYear" (ngModelChange)="onExpirationYearChange($event)"
-            (focus)="onDateFocus()" (blur)="onBlur()">
-            <option value disabled selected>{{resolvedFormLabels().expirationYear}}</option>
-            @for (element of [].constructor(12); track $index; let i = $index) {
-              <option [value]="minCardYear + i">{{i + minCardYear}}</option>
-            }
-          </select>
+          <div class="card-form__group-selects" [class.-error]="submitted() && (!isMonthValid() || !isYearValid())">
+            <select class="card-input__input -select" id="monthSelect"
+              [ngModel]="cardModel().expirationMonth" (ngModelChange)="onExpirationMonthChange($event)"
+              (focus)="onDateFocus()" (blur)="onBlur()">
+              <option value disabled selected>{{resolvedFormLabels().expirationMonth}}</option>
+              @for (element of [].constructor(12); track $index; let i = $index) {
+                <option [value]="(i+1) < 10 ? '0' + (i+1) : (i+1)" [disabled]="(i+1) < minCardMonth()">
+                  {{generateMonthValue((i+1))}}
+                </option>
+              }
+            </select>
+            <select class="card-input__input -select" [id]="yearSelectId"
+              [ngModel]="cardModel().expirationYear" (ngModelChange)="onExpirationYearChange($event)"
+              (focus)="onDateFocus()" (blur)="onBlur()">
+              <option value disabled selected>{{resolvedFormLabels().expirationYear}}</option>
+              @for (element of [].constructor(12); track $index; let i = $index) {
+                <option [value]="minCardYear + i">{{i + minCardYear}}</option>
+              }
+            </select>
+          </div>
+          @if (submitted() && (!isMonthValid() || !isYearValid())) {
+            <span class="card-input__error-msg">Please select an expiration date.</span>
+          }
         </div>
       </div>
       <div class="card-form__col -cvv">
-        <div class="card-input">
+        <div class="card-input" [class.-error]="submitted() && !isCvvValid()">
           <label for="cardCvv" class="card-input__label">{{resolvedFormLabels().cvv}}</label>
           <input class="card-input__input" type="tel" id="cardCvvId" maxlength="4" autocomplete="off"
             [value]="displayedCvv()" (blur)="onCvvBlur()" (focus)="onCvvFocus()" (input)="onCvvChange($event)" />
+          @if (submitted() && !isCvvValid()) {
+            <span class="card-input__error-msg">Please enter the CVV.</span>
+          }
         </div>
       </div>
     </div>
-    <button class="card-form__button" (click)="submitEvent.emit(cardModel())">{{resolvedFormLabels().submitButton}}</button>
+    <button class="card-form__button" (click)="onSubmitClick()">{{resolvedFormLabels().submitButton}}</button>
   </div>
 </div>

--- a/projects/ngx-interactive-paycard-lib/src/lib/interactive-paycard.component.scss
+++ b/projects/ngx-interactive-paycard-lib/src/lib/interactive-paycard.component.scss
@@ -90,6 +90,43 @@
     }
   }
 
+  &__group-selects {
+    display: flex;
+    width: 100%;
+
+    .card-input__input {
+      flex: 1;
+      margin-right: 15px;
+
+      &:last-child {
+        margin-right: 0;
+      }
+    }
+
+    &.-error .card-input__input {
+      border-color: #ff5252;
+    }
+  }
+
+  &__success {
+    background: #e8f5e9;
+    border: 1px solid #4caf50;
+    border-radius: 5px;
+    color: #2e7d32;
+    font-size: 15px;
+    font-weight: 500;
+    padding: 12px 16px;
+    margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__success-icon {
+    font-size: 18px;
+    font-weight: 700;
+  }
+
   &__button {
     width: 100%;
     height: 55px;
@@ -121,6 +158,18 @@
 .card-input {
   margin-bottom: 20px;
   position: relative;
+
+  &.-error .card-input__input {
+    border-color: #ff5252;
+  }
+
+  &__error-msg {
+    display: block;
+    color: #ff5252;
+    font-size: 12px;
+    margin-top: 4px;
+  }
+
   &__label {
     font-size: 14px;
     margin-bottom: 5px;

--- a/projects/ngx-interactive-paycard-lib/src/lib/interactive-paycard.component.spec.ts
+++ b/projects/ngx-interactive-paycard-lib/src/lib/interactive-paycard.component.spec.ts
@@ -72,7 +72,30 @@ describe('InteractivePaycardComponent', () => {
     expect(component.resolvedCardLabels()).toEqual(cardLabelsByDefaultMock);
   });
 
-  it('should emit an event when submit button is clicked', () => {
+  it('should emit an event when submit button is clicked with a valid form', () => {
+    // Arrange
+    const fixture = TestBed.createComponent(InteractivePaycardComponent);
+    fixture.componentRef.setInput('cardNumberFormat', '#### #### #### ####');
+    fixture.componentRef.setInput('cardNumberMask', '#### **** **** ####');
+    fixture.detectChanges();
+    const component = fixture.componentInstance;
+    vi.spyOn(component.submitEvent, 'emit');
+    component.cardModel.set({
+      cardNumber: '4539 1488 0343 6467',
+      cardName: 'John Doe',
+      expirationMonth: '12',
+      expirationYear: new Date().getFullYear().toString(),
+      cvv: '123'
+    });
+
+    // Act
+    component.onSubmitClick();
+
+    // Assert
+    expect(component.submitEvent.emit).toHaveBeenCalled();
+  });
+
+  it('should not emit an event when submit button is clicked with an invalid form', () => {
     // Arrange
     const fixture = TestBed.createComponent(InteractivePaycardComponent);
     const component = fixture.componentInstance;
@@ -82,7 +105,7 @@ describe('InteractivePaycardComponent', () => {
     component.onSubmitClick();
 
     // Assert
-    expect(component.submitEvent.emit).toHaveBeenCalled();
+    expect(component.submitEvent.emit).not.toHaveBeenCalled();
   });
 
   describe('minCardMonth', () => {
@@ -350,7 +373,7 @@ describe('InteractivePaycardComponent', () => {
     });
   });
 
-  describe('onCardNameKeyPress', () => {
+  describe('onCardNameChange', () => {
     let component: InteractivePaycardComponent;
 
     beforeEach(() => {
@@ -358,30 +381,25 @@ describe('InteractivePaycardComponent', () => {
       component = fixture.componentInstance;
     });
 
-    it('should exclude ASCII characters 64 and below, but allow 32', () => {
-      for (let i = 0; i < 65; i++) {
-        expect(component.onCardNameKeyPress({ charCode: i } as unknown as KeyboardEvent)).toBe(i === 32);
-      }
+    it('should allow letters', () => {
+      component.onCardNameChange('John');
+      expect(component.cardModel().cardName).toBe('John');
     });
-    it('should allow ASCII characters 65 thru 90', () => {
-      for (let i = 65; i < 91; i++) {
-        expect(component.onCardNameKeyPress({ charCode: i } as unknown as KeyboardEvent)).toBe(true);
-      }
+    it('should allow spaces', () => {
+      component.onCardNameChange('John Doe');
+      expect(component.cardModel().cardName).toBe('John Doe');
     });
-    it('should exclude ASCII characters 91 thru 96', () => {
-      for (let i = 91; i < 96; i++) {
-        expect(component.onCardNameKeyPress({ charCode: i } as unknown as KeyboardEvent)).toBe(false);
-      }
+    it('should allow hyphens', () => {
+      component.onCardNameChange('Mary-Jane');
+      expect(component.cardModel().cardName).toBe('Mary-Jane');
     });
-    it('should allow ASCII characters 97 thru 122', () => {
-      for (let i = 97; i < 123; i++) {
-        expect(component.onCardNameKeyPress({ charCode: i } as unknown as KeyboardEvent)).toBe(true);
-      }
+    it('should allow apostrophes', () => {
+      component.onCardNameChange("O'Brien");
+      expect(component.cardModel().cardName).toBe("O'Brien");
     });
-    it('should exclude ASCII characters above 122', () => {
-      for (let i = 123; i < 128; i++) {
-        expect(component.onCardNameKeyPress({ charCode: i } as unknown as KeyboardEvent)).toBe(false);
-      }
+    it('should strip digits and special characters', () => {
+      component.onCardNameChange('John123 @#$');
+      expect(component.cardModel().cardName).toBe('John ');
     });
   });
 

--- a/projects/ngx-interactive-paycard-lib/src/lib/interactive-paycard.component.ts
+++ b/projects/ngx-interactive-paycard-lib/src/lib/interactive-paycard.component.ts
@@ -196,7 +196,7 @@ export class InteractivePaycardComponent implements OnInit {
 
   onCardNameChange(name: string): void {
     // Only allow letters (including accented), spaces, hyphens, and apostrophes
-    const filtered = name.replace(/[^a-zA-Z\u00C0-\u024F '\-]/g, '');
+    const filtered = name.replace(/[^a-zA-Z\u00C0-\u024F ' -]/g, '');
     this.cardModel.update(m => ({ ...m, cardName: filtered }));
     this.onChangeCard();
   }

--- a/projects/ngx-interactive-paycard-lib/src/lib/interactive-paycard.component.ts
+++ b/projects/ngx-interactive-paycard-lib/src/lib/interactive-paycard.component.ts
@@ -57,9 +57,44 @@ export class InteractivePaycardComponent implements OnInit {
   readonly displayedCvv = signal('');
   readonly focusedElement = signal<FocusedElement | null>(null);
 
+  readonly submitted = signal(false);
+  readonly submitSuccess = signal(false);
+
   readonly cardNumberId = 'cardNumberId';
   readonly cardNameId = 'cardNameId';
   readonly yearSelectId = 'yearSelectId';
+
+  // Validation computeds
+  readonly cardNumberDigitCount = computed(() =>
+    (this.cardNumberFormat() ?? '').split('').filter(c => c === '#').length
+  );
+
+  readonly isAmexNumber = computed(() => {
+    const num = this.cardModel().cardNumber.replace(/ /g, '');
+    return num.length >= 2 && (num.startsWith('34') || num.startsWith('37'));
+  });
+
+  readonly formatSupportsAmex = computed(() => this.cardNumberDigitCount() === 15);
+
+  readonly showAmexWarning = computed(() => this.isAmexNumber() && !this.formatSupportsAmex());
+
+  readonly isCardNumberValid = computed(() => {
+    const num = this.cardModel().cardNumber.replace(/ /g, '');
+    return num.length === this.cardNumberDigitCount() && this.luhnCheck(num);
+  });
+
+  readonly isCardNameValid = computed(() => this.cardModel().cardName.trim().length >= 2);
+
+  readonly isMonthValid = computed(() => !!this.cardModel().expirationMonth);
+
+  readonly isYearValid = computed(() => !!this.cardModel().expirationYear);
+
+  readonly isCvvValid = computed(() => this.cardModel().cvv.length >= 3);
+
+  readonly isFormValid = computed(() =>
+    this.isCardNumberValid() && this.isCardNameValid() &&
+    this.isMonthValid() && this.isYearValid() && this.isCvvValid()
+  );
 
   ngOnInit() {
     const format = this.cardNumberFormat();
@@ -159,14 +194,11 @@ export class InteractivePaycardComponent implements OnInit {
     this.onBlur();
   }
 
-  onCardNameKeyPress($event: KeyboardEvent): boolean {
-    this.onChangeCard();
-    return (($event.charCode >= 65 && $event.charCode <= 90) ||
-      ($event.charCode >= 97 && $event.charCode <= 122) || ($event.charCode === 32));
-  }
-
   onCardNameChange(name: string): void {
-    this.cardModel.update(m => ({ ...m, cardName: name }));
+    // Only allow letters (including accented), spaces, hyphens, and apostrophes
+    const filtered = name.replace(/[^a-zA-Z\u00C0-\u024F '\-]/g, '');
+    this.cardModel.update(m => ({ ...m, cardName: filtered }));
+    this.onChangeCard();
   }
 
   onMonthChange(): void {
@@ -190,8 +222,15 @@ export class InteractivePaycardComponent implements OnInit {
     this.onYearChange();
   }
 
-  onSubmitClick() {
+  onSubmitClick(): void {
+    this.submitted.set(true);
+    if (!this.isFormValid()) {
+      return;
+    }
     this.submitEvent.emit(this.cardModel());
+    this.resetForm();
+    this.submitSuccess.set(true);
+    setTimeout(() => this.submitSuccess.set(false), 3000);
   }
 
   onChangeCard() {
@@ -212,6 +251,28 @@ export class InteractivePaycardComponent implements OnInit {
 
   generateMonthValue(index: number): string {
     return index < 10 ? `0${index}` : index.toString();
+  }
+
+  private resetForm(): void {
+    this.cardModel.set({ cardNumber: '', cardName: '', expirationMonth: '', expirationYear: '', cvv: '' });
+    this.displayedCardNumber.set('');
+    this.displayedCvv.set('');
+    this.submitted.set(false);
+  }
+
+  private luhnCheck(num: string): boolean {
+    let sum = 0;
+    let isEven = false;
+    for (let i = num.length - 1; i >= 0; i--) {
+      let digit = parseInt(num[i], 10);
+      if (isEven) {
+        digit *= 2;
+        if (digit > 9) digit -= 9;
+      }
+      sum += digit;
+      isEven = !isEven;
+    }
+    return sum % 10 === 0;
   }
 
   private maskCardNumber(): void {


### PR DESCRIPTION
Closes #44

## Summary

- **Bug 1 — Form validation feedback:** Each field now shows a red border and an inline error message when the form is submitted incomplete. Errors are only revealed after the first submit attempt, so first-time visitors aren't bombarded.
- **Bug 2 — Success message:** A green success banner ("Payment submitted successfully!") appears for 3 seconds after a valid submission.
- **Bug 3 — Inconsistent reset:** `onSubmitClick` now calls `resetForm()` which sets the full `CardModel` (including `expirationMonth` and `expirationYear`) back to empty strings, so all fields — including the two selects — reset consistently.
- **Bug 4 — Card name accepts invalid chars:** Replaced the broken `keyup` return-value guard (which had no effect) with a regex filter inside `onCardNameChange`. Only letters (including accented/extended Latin), spaces, hyphens, and apostrophes are allowed.
- **Bug 5 — No Luhn validation:** Added a `luhnCheck()` private method. `isCardNumberValid` is only `true` when the digit count matches the format **and** the number passes Luhn. An error message is shown on submit if it fails.
- **Bug 6 — Amex silent rejection:** Added `isAmexNumber` and `formatSupportsAmex` computeds. When an Amex prefix (34/37) is detected but the configured format does not support 15-digit numbers, a persistent warning "American Express cards are not supported." is shown below the card number field.

## Test plan

- [ ] Submit empty form → all fields highlight red with error messages
- [ ] Fill only some fields, submit → only invalid fields show errors
- [ ] Fill all fields with a valid Luhn card number (e.g. `4539 1488 0343 6467`) → success banner appears, all fields (including Month/Year) reset
- [ ] Type `abc 123 @#$` in Card Holder Name → only letters pass through
- [ ] Enter `1234 5678 9012 3456` (fails Luhn) → error shown on submit
- [ ] Enter `3782 8224 6310 005` (Amex, 15 digits) → warning shown inline immediately
- [ ] Enter a valid 16-digit Visa number → no Amex warning shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)